### PR TITLE
Fix to exceeding lock count limit while clustering. locking happened …

### DIFF
--- a/src/de/uni_leipzig/informatik/asv/gephi/chinesewhispers/ChineseWhispersClusterer.java
+++ b/src/de/uni_leipzig/informatik/asv/gephi/chinesewhispers/ChineseWhispersClusterer.java
@@ -91,6 +91,7 @@ public class ChineseWhispersClusterer implements Clusterer, LongTask {
         for (Node node : graph.getNodes()) {
           if (unconnected == Unconnected.INDIVIDUAL) classes.put(node, counter++);
           if (graph.getNeighbors(node).iterator().hasNext()) {
+              graph.readUnlock();
               connectedNodes.add(node);
               if (unconnected != Unconnected.INDIVIDUAL) classes.put(node, counter++);
           }


### PR DESCRIPTION
…on graph when neighbours are being checked. But they were not unlocked. This had caused "Maximum lock count exceeded" error for large graphs. Fix is to explicitly unlock after successful checking of presence of neighbours.